### PR TITLE
include messages by default in installed_apps and context processors

### DIFF
--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -96,6 +96,7 @@ def common(**kwargs):
         'django.contrib.sites',
         'django.contrib.flatpages',
         'django.contrib.staticfiles',
+        'django.contrib.messages',
         'django.contrib.admin',
         'django_statsd',
         'smoketest',

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -64,6 +64,7 @@ def common(**kwargs):
         'django.contrib.auth.context_processors.auth',
         'django.template.context_processors.debug',
         'django.template.context_processors.request',
+        'django.contrib.messages.context_processors.messages',
         'django.template.context_processors.static',
         'djangowind.context.context_processor',
         'stagingcontext.staging_processor',


### PR DESCRIPTION
Because we are including the messages middleware by default, we should
also include `django.contrib.messages` in INSTALLED_APPS, because it's
required for the messaging stuff to work. I've also added the messages context
processor to TEMPLATE_CONTEXT_PROCESSORS because that's also
required.

https://docs.djangoproject.com/en/1.9/ref/contrib/messages/#enabling-messages
