### PR TITLE
Set DEFAULT_FROM_EMAIL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.1.4 (2016-1-28)
+==================
+* set DEFAULT_FROM_EMAIL
+
 0.1.3 (2015-12-17)
 ==================
 * fix MEDIA_ROOT path for staging

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -131,6 +131,7 @@ def common(**kwargs):
     EMAIL_SUBJECT_PREFIX = "[" + project + "] "
     EMAIL_HOST = 'localhost'
     SERVER_EMAIL = project + "@ccnmtl.columbia.edu"
+    DEFAULT_FROM_EMAIL = SERVER_EMAIL
 
     STATICMEDIA_MOUNTS = [
         ('/sitemedia', 'sitemedia'),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ccnmtlsettings",
-    version="0.1.3",
+    version="0.1.4",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/ccnmtlsettings",


### PR DESCRIPTION
Registration and other modules use DEFAULT_FROM_EMAIL as the sender address for outgoing mails.
The Django default "webmaster@localhost" is resulting in bounces with the error "Real domain name required for sender address (in reply to MAIL FROM command))"
