### PR TITLE
Change Password Hashing For Tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
-0.1.5 (2015-02-24)
+0.1.6 (2016-03-12)
 ==================
+* select a significantly faster password hashing method for unit tests
 
+0.1.5 (2016-02-24)
+==================
 * include Cassandra in superusers list
 
 0.1.4 (2016-01-28)

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -40,6 +40,10 @@ def common(**kwargs):
             }
         }
 
+        PASSWORD_HASHERS = (
+            'django.contrib.auth.hashers.MD5PasswordHasher',
+        )
+
     JENKINS_TASKS = [
         'django_jenkins.tasks.run_pep8',
         'django_jenkins.tasks.run_pyflakes',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ccnmtlsettings",
-    version="0.1.5",
+    version="0.1.6",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/ccnmtlsettings",


### PR DESCRIPTION
From [Effective TDD: Tricks to speed up Django tests](http://www.daveoncode.com/2013/09/23/effective-tdd-tricks-to-speed-up-django-tests-up-to-10x-faster/). Implementing the first suggestion, "change password hashing", results in a very, very significant speed increase.

also [doc'd here](https://docs.djangoproject.com/en/1.9/topics/testing/overview/#speeding-up-tests-auth-hashers)

For Mediathead:  
- pre - Ran 333 tests in 415.573s
- post - Ran 333 tests in 45.476s
