### PR TITLE
support s3prefix param for more flexible bucket names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+* allow S3 bucket prefix to be overridden with the `s3prefix`
+  parameter
+
 1.0.0 (2016-08-03)
 ==================
 

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -12,6 +12,7 @@ def common(**kwargs):
     # optional args
     s3static = kwargs.get('s3static', True)
     cloudfront = kwargs.get('cloudfront', None)
+    s3prefix = kwargs.get('s3prefix', 'ccnmtl')
 
     DEBUG = False
 
@@ -35,7 +36,7 @@ def common(**kwargs):
 
     if s3static:
         # serve static files off S3
-        AWS_STORAGE_BUCKET_NAME = "ccnmtl-" + project + "-static-prod"
+        AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
         AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -12,6 +12,7 @@ def common(**kwargs):
     # optional args
     s3static = kwargs.get('s3static', True)
     cloudfront = kwargs.get('cloudfront', None)
+    s3prefix = kwargs.get('s3prefix', 'ccnmtl')
 
     DEBUG = False
     STAGING_ENV = True
@@ -39,7 +40,7 @@ def common(**kwargs):
 
     if s3static:
         # serve static files off S3
-        AWS_STORAGE_BUCKET_NAME = "ccnmtl-" + project + "-static-stage"
+        AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
         AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:


### PR DESCRIPTION
this will allow us to switch to 'ctl-' buckets and ease conversion to
terraform managed buckets.
