### PR TITLE
Move TEMPLATE_DEBUG into TEMPLATES

### DIFF
--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -8,7 +8,6 @@ def common(**kwargs):
     base = kwargs['base']
 
     DEBUG = True
-    TEMPLATE_DEBUG = DEBUG
 
     ADMINS = []
     MANAGERS = ADMINS
@@ -71,6 +70,7 @@ def common(**kwargs):
             ],
             'APP_DIRS': True,
             'OPTIONS': {
+                'debug': DEBUG,
                 'context_processors': [
                     # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
                     # list if you haven't customized them:


### PR DESCRIPTION
Addressing this warning:

> ?: (1_8.W001) The standalone TEMPLATE_\* settings were deprecated in
> Django 1.8 and the TEMPLATES dictionary takes precedence. You must put
> the values of the following settings into your default TEMPLATES dict:
> TEMPLATE_DEBUG.

https://docs.djangoproject.com/en/1.8/ref/settings/#template-debug
