### PR TITLE
Remove standalone TEMPLATE_DEBUG reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 .project
 .pydevproject
+*.pyc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+1.1.3 (2016-09-30)
+==================
+
+* TEMPLATE_DEBUG is deprecated. Using the new `debug` key under
+`TEMPLATES['OPTIONS']`
+
 1.1.2 (2016-09-26)
 ==================
 

--- a/ccnmtlsettings/docker.py
+++ b/ccnmtlsettings/docker.py
@@ -47,6 +47,7 @@ def common(**kwargs):
     # -------------------------------------------
 
     DEBUG = False
+    TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa
 
     DATABASES = {
         'default': {

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -14,6 +14,7 @@ def common(**kwargs):
     s3prefix = kwargs.get('s3prefix', 'ccnmtl')
 
     DEBUG = False
+    TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa
 
     DATABASES = {
         'default': {

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -8,7 +8,6 @@ def common(**kwargs):
     base = kwargs['base']
 
     DEBUG = True
-    TEMPLATE_DEBUG = DEBUG
 
     ADMINS = []
     MANAGERS = ADMINS
@@ -71,6 +70,7 @@ def common(**kwargs):
             ],
             'APP_DIRS': True,
             'OPTIONS': {
+                'debug': True,
                 'context_processors': [
                     # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
                     # list if you haven't customized them:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -14,6 +14,7 @@ def common(**kwargs):
     s3prefix = kwargs.get('s3prefix', 'ccnmtl')
 
     DEBUG = False
+    TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa
     STAGING_ENV = True
 
     DATABASES = {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ccnmtlsettings",
-    version="1.1.2",
+    version="1.1.3",
     author="Anders Pearson",
     author_email="anders@columbia.edu",
     url="https://github.com/ccnmtl/ccnmtlsettings",


### PR DESCRIPTION
Per [the upgrade docs](https://docs.djangoproject.com/en/1.8/ref/templates/upgrading/), if [settings] sets TEMPLATE_DEBUG to a value that differs from DEBUG, include that value under the 'debug' key in 'OPTIONS'. 
