### PR TITLE
Add AWS_DEFAULT_ACL setting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+* Add AWS_DEFAULT_ACL = 'public-read'
+
 1.5.0 (2019-01-31)
 ==================
 * Update SERVER_EMAIL to project@mail.ctl.columbia.edu

--- a/ccnmtlsettings/docker.py
+++ b/ccnmtlsettings/docker.py
@@ -32,6 +32,7 @@ def common(**kwargs):
 
     AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
     AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+    AWS_DEFAULT_ACL = 'public-read'
     AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', '')
     AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', '')
     AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -36,6 +36,7 @@ def common(**kwargs):
     if s3static:
         # serve static files off S3
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
+        AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -40,6 +40,7 @@ def common(**kwargs):
     if s3static:
         # serve static files off S3
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
+        AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:


### PR DESCRIPTION
This is an optional setting that django-storages recommends to be set to
something. We use public-read for this.

https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html