### PR TITLE
Adding security settings

### DIFF
--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -98,6 +98,9 @@ def common(**kwargs):
         'django.contrib.messages.middleware.MessageMiddleware',
         'waffle.middleware.WaffleMiddleware',
         'impersonate.middleware.ImpersonateMiddleware',
+        'django.middleware.security.SecurityMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware'
     ]
 
     ROOT_URLCONF = project + '.urls'
@@ -165,7 +168,12 @@ def common(**kwargs):
 
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
     SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
     SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SECURE = True
+
+    CSRF_COOKIE_SECURE = True
+    CSRF_COOKIE_HTTPONLY = True
 
     STATIC_ROOT = "/tmp/" + project + "/static"
     STATICFILES_DIRS = ["media/"]


### PR DESCRIPTION
Rather than add these for all projects (der), adding them in our base settings.

* Add X-Frame-Option header to all responses
The header value is set to SAMEORIGIN by default. See more (https://docs.djangoproject.com/en/2.2/ref/clickjacking/)

* Set HttpOnly flag for Django cookies
https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-httponly and https://docs.djangoproject.com/en/2.2/ref/settings/#session-cookie-httponly

* Flag CSRF cooke as secure
https://docs.djangoproject.com/en/2.2/ref/settings/#csrf-cookie-secure

* Add SecurityMiddleware
https://docs.djangoproject.com/en/2.2/ref/middleware/#module-django.middleware.security

* Add CSRF Middleware
https://docs.djangoproject.com/en/2.2/ref/middleware/#csrf-protection-middleware