### PR TITLE
Pulling the CSRF middleware from this release

### DIFF
--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -99,8 +99,7 @@ def common(**kwargs):
         'waffle.middleware.WaffleMiddleware',
         'impersonate.middleware.ImpersonateMiddleware',
         'django.middleware.security.SecurityMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware'
+        'django.middleware.clickjacking.XFrameOptionsMiddleware'
     ]
 
     ROOT_URLCONF = project + '.urls'


### PR DESCRIPTION
We'll deal with this separately as the changes might be too extensive.