### PR TITLE
Update CSRF_COOKIE_HTTPONLY to False

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.8.1
+==================
+* Change `CSRF_COOKIE_HTTPONLY` to False.
+
 1.8.0 (2020-01-23)
 ==================
 * Replace django-jenkins with coverage

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -166,7 +166,7 @@ def common(**kwargs):
     SESSION_COOKIE_SECURE = True
 
     CSRF_COOKIE_SECURE = True
-    CSRF_COOKIE_HTTPONLY = True
+    CSRF_COOKIE_HTTPONLY = False
 
     STATIC_ROOT = "/tmp/" + project + "/static"
     STATICFILES_DIRS = ["media/"]


### PR DESCRIPTION
Change CSRF_COOKIE_HTTPONLY back to its default value of False.
The csrf token should be readable by JavaScript - we use this for making
authed XHR requests.

Setting this to True doesn't actually close any vulnerabilities, see the
description here: https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-CSRF_COOKIE_HTTPONLY