### PR TITLE
:bookmark: release version 1.8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.8.2 (2020-05-28)
+==================
+* Fix s3boto3 module path name
+
 1.8.1 (2020-05-28)
 ==================
 * Use s3boto3 storage backend from django-storages, for compatibility

--- a/ccnmtlsettings/docker.py
+++ b/ccnmtlsettings/docker.py
@@ -62,13 +62,13 @@ def common(**kwargs):
         DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
         # static data, e.g. css, js, etc.
-        STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+        STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
         COMPRESS_ENABLED = True
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        COMPRESS_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+        COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
     LOGGING = {
         'version': 1,

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -35,7 +35,7 @@ def common(**kwargs):
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
         AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
-        STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+        STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -48,8 +48,8 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
-        COMPRESS_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -39,7 +39,7 @@ def common(**kwargs):
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
         AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
-        STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+        STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -52,8 +52,8 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
-        COMPRESS_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="ccnmtlsettings",
-    version="1.8.1",
+    version="1.8.2",
     author="Anders Pearson",
     author_email="ctl-dev@columbia.edu",
     url="https://github.com/ccnmtl/ccnmtlsettings",


### PR DESCRIPTION
With storages s3boto3 path fix. I had the wrong module path name here.

It should be as specified in these docs:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html