### PR TITLE
Subclass S3Boto3Storage to specify locations

### DIFF
--- a/ccnmtlsettings/docker.py
+++ b/ccnmtlsettings/docker.py
@@ -62,13 +62,13 @@ def common(**kwargs):
         DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
         # static data, e.g. css, js, etc.
-        STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        STATICFILES_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
         STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
         COMPRESS_ENABLED = True
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        COMPRESS_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
 
     LOGGING = {
         'version': 1,

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -48,7 +48,7 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.UploadsS3Boto3Storage'
         COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -35,7 +35,7 @@ def common(**kwargs):
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
         AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
-        STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        STATICFILES_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -48,8 +48,8 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.UploadsS3Boto3Storage'
-        COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.MediaRootS3Boto3Storage'
+        COMPRESS_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -52,7 +52,7 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.UploadsS3Boto3Storage'
         COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -39,7 +39,7 @@ def common(**kwargs):
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
         AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
-        STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        STATICFILES_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -52,8 +52,8 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.UploadsS3Boto3Storage'
-        COMPRESS_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.MediaRootS3Boto3Storage'
+        COMPRESS_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ccnmtlsettings/storage.py
+++ b/ccnmtlsettings/storage.py
@@ -1,5 +1,9 @@
 from storages.backends.s3boto3 import S3Boto3Storage
 
 
-class UploadsS3Boto3Storage(S3Boto3Storage):
+class CompressorS3Boto3Storage(S3Boto3Storage):
+    location = 'media'
+
+
+class MediaRootS3Boto3Storage(S3Boto3Storage):
     location = 'uploads'

--- a/ccnmtlsettings/storage.py
+++ b/ccnmtlsettings/storage.py
@@ -1,0 +1,5 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class UploadsS3Boto3Storage(S3Boto3Storage):
+    location = 'uploads'


### PR DESCRIPTION
The recent [boto3 upgrade](https://github.com/ccnmtl/ccnmtlsettings/pull/46/files) removed an old dependency on the [django-cachedstorages library](https://github.com/ccnmtl/django-cacheds3storage/blob/master/cacheds3storage/__init__.py) that interfered with a django-storages upgrade.

`django-cachedstorages` was primarily added to [patch a boto3 bug which has since been resolved](https://github.com/jschneier/django-storages/issues/382#issuecomment-377174808). 

`django-cachedstorages` also [specified locations (subdirectories) where particular files should be accessed](https://github.com/ccnmtl/django-cacheds3storage/blob/master/cacheds3storage/__init__.py#L66). This PR restores those locations to ensure static files continue to be sorted to the `media` directory and uploaded files are found in the `uploads` directory.