### PR TITLE
Use cacheds3storage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+1.8.4
+==================
+* Use django-cacheds3storage again, for
+  django-compressor/django-storages integration.
+
 1.8.3 (2020-06-01)
 ==================
 * Specify directories for static & uploaded files

--- a/ccnmtlsettings/docker.py
+++ b/ccnmtlsettings/docker.py
@@ -59,16 +59,16 @@ def common(**kwargs):
 
     if AWS_S3_CUSTOM_DOMAIN:
         AWS_PRELOAD_METADATA = True
-        DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
         # static data, e.g. css, js, etc.
-        STATICFILES_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
+        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
         COMPRESS_ENABLED = True
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        COMPRESS_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
+        COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
 
     LOGGING = {
         'version': 1,

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -35,7 +35,7 @@ def common(**kwargs):
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
         AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
-        STATICFILES_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
+        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -48,8 +48,8 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.MediaRootS3Boto3Storage'
-        COMPRESS_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
+        COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -39,7 +39,7 @@ def common(**kwargs):
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
         AWS_DEFAULT_ACL = 'public-read'
         AWS_PRELOAD_METADATA = True
-        STATICFILES_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
+        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -52,8 +52,8 @@ def common(**kwargs):
         COMPRESS_OFFLINE = True
         COMPRESS_ROOT = STATIC_ROOT
         COMPRESS_URL = STATIC_URL
-        DEFAULT_FILE_STORAGE = 'ccnmtlsettings.storage.MediaRootS3Boto3Storage'
-        COMPRESS_STORAGE = 'ccnmtlsettings.storage.CompressorS3Boto3Storage'
+        DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
+        COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ccnmtlsettings/storage.py
+++ b/ccnmtlsettings/storage.py
@@ -1,9 +1,0 @@
-from storages.backends.s3boto3 import S3Boto3Storage
-
-
-class CompressorS3Boto3Storage(S3Boto3Storage):
-    location = 'media'
-
-
-class MediaRootS3Boto3Storage(S3Boto3Storage):
-    location = 'uploads'


### PR DESCRIPTION
Use the package we created here, again:
https://github.com/ccnmtl/django-cacheds3storage

This should add back in integration between django-compressor and
django-storages. I realized this while reading django-compressor's docs
here:
https://django-compressor.readthedocs.io/en/stable/remote-storages/#using-staticfiles

This got lost during the django-storages / boto3 update, when I reverted
to django-storage's default classes for this. But, our cacheds3storage
is now compatible with the new boto3, so this should work.