### PR TITLE
Change django-storages-redux requirement back to django-storages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ The following libraries are used in some way, so they'll need to be installed:
 * django-extensions
 * django-statsd-mozilla
 * django-markwhat
-* django-storages-redux
+* django-storages
 * django-impersonate
 * boto3
 * sentry-sdk

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "django-statsd-mozilla",
         "sentry-sdk",
         "django-markwhat",
-        "django-storages-redux",
+        "django-storages",
         "boto3",
         "statsd",
         "gunicorn",


### PR DESCRIPTION
django-storages version 1.10.1 is now the version that we're using for our latest apps.