### PR TITLE
Use new postgresql engine name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.9.1
+==================
+* Fix postgresql engine name
+
 1.9.0 (2020-09-15)
 ==================
 * Remove python 2 support

--- a/ccnmtlsettings/compose.py
+++ b/ccnmtlsettings/compose.py
@@ -11,7 +11,7 @@ def common(**kwargs):
     DEBUG = True
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': 'postgres',
             'USER': 'postgres',
             'HOST': 'db',

--- a/ccnmtlsettings/docker.py
+++ b/ccnmtlsettings/docker.py
@@ -48,7 +48,7 @@ def common(**kwargs):
 
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': DB_NAME,
             'HOST': DB_HOST,
             'PORT': DB_PORT,

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -14,7 +14,7 @@ def common(**kwargs):
 
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': project,
             'HOST': '',
             'PORT': 6432,

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -20,7 +20,7 @@ def common(**kwargs):
 
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': project,
             'HOST': '',
             'PORT': 5432,

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -15,7 +15,7 @@ def common(**kwargs):
 
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'ENGINE': 'django.db.backends.postgresql',
             'NAME': project,
             'HOST': '',
             'PORT': 6432,


### PR DESCRIPTION
This was renamed from "postgresql_psycopg2" to just "postgresql" in
django 1.9.

https://docs.djangoproject.com/en/3.1/releases/1.9/#database-backends