### PR TITLE
Remove public-read global setting for ACL

### DIFF
--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -33,9 +33,6 @@ def common(**kwargs):
     if s3static:
         # serve static files off S3
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
-        AWS_S3_OBJECT_PARAMETERS = {
-            'ACL': 'public-read',
-        }
         AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -37,9 +37,6 @@ def common(**kwargs):
     if s3static:
         # serve static files off S3
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
-        AWS_S3_OBJECT_PARAMETERS = {
-            'ACL': 'public-read',
-        }
         AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:


### PR DESCRIPTION
This setting was originally introduced in this commit, because
apparently django-storages recommended it be set:

bfb7579f2679a7e2f2d0f6b356318d35a532a2f2

This is no longer the case - it's completely optional:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html

And when it's not set, it defaults to using the bucket's ACL, which is
what we want.

This change fixes our mediathread private bucket uploading issue - these
uploads should happen with a private acl, not 'public-read'.