### PR TITLE
Enable file logging in django

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.9.2
+==================
+* Enable django file logging
+
 1.9.1 (2021-08-04)
 ==================
 * Fix postgresql engine name

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -181,7 +181,21 @@ def common(**kwargs):
 
     LOGGING = {
         'version': 1,
-        'disable_existing_loggers': True,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'file': {
+                'level': 'DEBUG',
+                'class': 'logging.FileHandler',
+                'filename': '/var/log/django/' + project + '/debug.log',
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': ['file'],
+                'level': 'DEBUG',
+                'propagate': True,
+            },
+        },
     }
 
     GRAPHITE_BASE = "https://graphite.ctl.columbia.edu/render/"


### PR DESCRIPTION
According to these django docs, it's not actually recommended to use
`'disable_existing_loggers': True`. Let's configure file logging
on our django servers, and then set up log rotation for these logs.

https://docs.djangoproject.com/en/2.2/topics/logging/#configuring-logging