### PR TITLE
Update log path to /var/log/django/<project>.log

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.9.5
+==================
+* Update project log path
+
 1.9.4 (2022-08-25)
 ==================
 * Decrease file logging level to INFO

--- a/ccnmtlsettings/production.py
+++ b/ccnmtlsettings/production.py
@@ -67,7 +67,7 @@ def common(**kwargs):
             'file': {
                 'level': 'INFO',
                 'class': 'logging.FileHandler',
-                'filename': '/var/log/django/' + project + '/debug.log',
+                'filename': '/var/log/django/' + project + '.log',
             },
         },
         'loggers': {

--- a/ccnmtlsettings/staging.py
+++ b/ccnmtlsettings/staging.py
@@ -71,7 +71,7 @@ def common(**kwargs):
             'file': {
                 'level': 'INFO',
                 'class': 'logging.FileHandler',
-                'filename': '/var/log/django/' + project + '/debug.log',
+                'filename': '/var/log/django/' + project + '.log',
             },
         },
         'loggers': {


### PR DESCRIPTION
I should have done this in the first place - we don't need to create a new directory for each project.