### PR TITLE
Remove django-waffle from common settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 1.9.5
 ==================
-* Update project log path
+* Updated project log path
+* Removed django-waffle
 
 1.9.4 (2022-08-25)
 ==================

--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,6 @@ The following libraries are used in some way, so they'll need to be installed:
 
 * django_compressor
 * django-debug-toolbar
-* django-waffle
 * coverage
 * django-smoketest
 * django-extensions

--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -91,7 +91,6 @@ def common(**kwargs):
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
-        'waffle.middleware.WaffleMiddleware',
         'impersonate.middleware.ImpersonateMiddleware',
         'django.middleware.security.SecurityMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(
     install_requires = [
         "django_compressor",
         "django-debug-toolbar",
-        "django-waffle",
         "coverage",
         "django-smoketest",
         "django-extensions",


### PR DESCRIPTION
django-waffle is a feature flipper that we only rarely use these days. Feature flags can be useful, but they also can introduce complexity to an application.

In any case, I think it's fine to just manually include django-waffle in the case that we do want to use a feature flag. It definitely doesn't need to be included in all our projects.