### PR TITLE
Remove 'waffle' from INSTALLED_APPS

### DIFF
--- a/ccnmtlsettings/shared.py
+++ b/ccnmtlsettings/shared.py
@@ -113,7 +113,6 @@ def common(**kwargs):
         'compressor',
         'djangowind',
         'impersonate',
-        'waffle',
         'django_markwhat',
     ]
 


### PR DESCRIPTION
I missed this when removing django-waffle from this library.